### PR TITLE
Add VS Code settings for C# Dev Kit test discovery

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "omnisharp.enableEditorConfigSupport": true,
+  "omnisharp.enableRoslynAnalyzers": true,
+  "dotnet.defaultSolution": "media-encoding.sln"
+}


### PR DESCRIPTION
Configure dotnet.defaultSolution to ensure test explorer properly discovers xUnit tests in VS Code.