### PR TITLE
Fix Makefile after project rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ help:
 
 # Restore NuGet packages
 restore:
-	dotnet restore media-encoding.sln
+	dotnet restore RipSharp.sln
 
 # Build the solution
 build: restore
-	dotnet build media-encoding.sln
+	dotnet build RipSharp.sln
 
 # Run code formatter
 format: restore
-	dotnet format media-encoding.sln
+	dotnet format RipSharp.sln
 
 # Run tests
 test: build
-	dotnet test media-encoding.sln
+	dotnet test RipSharp.sln
 
 # Clean build outputs
 clean:
-	dotnet clean media-encoding.sln
+	dotnet clean RipSharp.sln

--- a/src/RipSharp.Tests/GlobalUsings.cs
+++ b/src/RipSharp.Tests/GlobalUsings.cs
@@ -1,5 +1,6 @@
 // Global using directives for test files
 global using AwesomeAssertions;
+
 global using RipSharp.Abstractions;
 global using RipSharp.Core;
 global using RipSharp.MakeMkv;


### PR DESCRIPTION
Closes #39

## Problem
The Makefile was still referencing `media-encoding.sln` (the old project name) instead of `RipSharp.sln`, causing all make commands to fail.

## Solution
Updated all solution references in the Makefile from `media-encoding.sln` to `RipSharp.sln`.

## Verification
Tested all Makefile targets successfully:
- ✅ `make help` - Shows available targets
- ✅ `make restore` - Restores NuGet packages
- ✅ `make build` - Builds the solution
- ✅ `make test` - Runs all 112 tests (all pass)
- ✅ `make format` - Runs dotnet format
- ✅ `make clean` - Cleans build outputs
- ✅ `make all` - Default target (build + test)