### PR TITLE
Add config file discovery and defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@
 - Write XML documentation comments for public APIs.
 - Follow SOLID principles and best practices.
 - Use meaningful commit messages that describe the changes made.
+- Use dependency injection where appropriate to improve testability and maintainability.
 
 ## Changes and Validation
 
@@ -20,3 +21,4 @@
 - Run relevant tests when asked or after non-trivial changes.
 - Run `dotnet format` before submitting changes.
 - Follow `.editorconfig` settings when adding new code or modifying existing code.
+- Run commands in the main terminal so output is visible to the user.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,34 @@ If you version from git tags in CI, pass the tag version as `/p:Version=1.2.3` d
 | `OMDB_API_KEY`  | OMDB API key for metadata lookup (optional)    |
 | `TVDB_API_KEY`  | TVDB API key for TV episode titles (optional)  |
 
+## Configuration File
+
+RipSharp loads configuration from the first file it finds in these locations:
+
+Linux:
+
+1. `$XDG_CONFIG_HOME/ripsharp/config.yaml`
+2. `$HOME/.config/ripsharp/config.yaml`
+3. `$HOME/.ripsharp.yaml`
+4. `./ripsharp.yaml`
+5. `./appsettings.yaml`
+
+Windows:
+
+1. `%APPDATA%/ripsharp/config.yaml`
+2. `%USERPROFILE%/.ripsharp.yaml`
+3. `./ripsharp.yaml`
+4. `./appsettings.yaml`
+
+macOS:
+
+1. `$HOME/.config/ripsharp/config.yaml`
+2. `$HOME/.ripsharp.yaml`
+3. `./ripsharp.yaml`
+4. `./appsettings.yaml`
+
+If no config file exists, RipSharp creates one in the first personal location above (for example, `$XDG_CONFIG_HOME/ripsharp/config.yaml` on Linux).
+
 ## Building
 
 ```bash

--- a/src/RipSharp.Tests/Core/ConfigFileLocatorTests.cs
+++ b/src/RipSharp.Tests/Core/ConfigFileLocatorTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.IO;
+
+using AwesomeAssertions;
+
+using Xunit;
+
+namespace BugZapperLabs.RipSharp.Tests.Core;
+
+public class ConfigFileLocatorTests
+{
+    [Fact]
+    public void GetCandidatePaths_Linux_WithXdgConfigHome_UsesExpectedOrder()
+    {
+        var context = new ConfigSearchContext(
+            "/xdg",
+            "/home/tester",
+            "/appdata",
+            "/work",
+            IsWindows: false,
+            IsMac: false,
+            IsLinux: true);
+
+        var candidates = ConfigFileLocator.GetCandidatePaths(context);
+
+        candidates.Should().ContainInOrder(
+            Path.Combine("/xdg", "ripsharp", "config.yaml"),
+            Path.Combine("/home/tester", ".config", "ripsharp", "config.yaml"),
+            Path.Combine("/home/tester", ".ripsharp.yaml"),
+            Path.Combine("/work", "ripsharp.yaml"),
+            Path.Combine("/work", "appsettings.yaml"));
+    }
+
+    [Fact]
+    public void GetCandidatePaths_Linux_WithoutXdgConfigHome_UsesHomeConfigFirst()
+    {
+        var context = new ConfigSearchContext(
+            null,
+            "/home/tester",
+            "/appdata",
+            "/work",
+            IsWindows: false,
+            IsMac: false,
+            IsLinux: true);
+
+        var candidates = ConfigFileLocator.GetCandidatePaths(context);
+
+        candidates.Should().ContainInOrder(
+            Path.Combine("/home/tester", ".config", "ripsharp", "config.yaml"),
+            Path.Combine("/home/tester", ".ripsharp.yaml"),
+            Path.Combine("/work", "ripsharp.yaml"),
+            Path.Combine("/work", "appsettings.yaml"));
+    }
+
+    [Fact]
+    public void ResolveConfigPath_CreatesConfigWhenMissingAndNotDevelopment()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"ripsharp-config-{Path.GetRandomFileName()}");
+        var xdgDir = Path.Combine(tempRoot, "xdg");
+        Directory.CreateDirectory(xdgDir);
+
+        try
+        {
+            var context = new ConfigSearchContext(
+                xdgDir,
+                Path.Combine(tempRoot, "home"),
+                Path.Combine(tempRoot, "appdata"),
+                Path.Combine(tempRoot, "work"),
+                IsWindows: false,
+                IsMac: false,
+                IsLinux: true);
+
+            var configPath = ConfigFileLocator.ResolveConfigPath(
+                context,
+                isDevelopment: false,
+                File.Exists,
+                File.WriteAllText,
+                path => Directory.CreateDirectory(path));
+
+            configPath.Should().Be(Path.Combine(xdgDir, "ripsharp", "config.yaml"));
+            File.Exists(configPath).Should().BeTrue();
+            var contents = File.ReadAllText(configPath!);
+            contents.Should().Contain("disc:");
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveConfigPath_DoesNotCreateConfigInDevelopment()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"ripsharp-config-{Path.GetRandomFileName()}");
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var context = new ConfigSearchContext(
+                tempRoot,
+                Path.Combine(tempRoot, "home"),
+                Path.Combine(tempRoot, "appdata"),
+                Path.Combine(tempRoot, "work"),
+                IsWindows: false,
+                IsMac: false,
+                IsLinux: true);
+
+            var configPath = ConfigFileLocator.ResolveConfigPath(
+                context,
+                isDevelopment: true,
+                File.Exists,
+                File.WriteAllText,
+                path => Directory.CreateDirectory(path));
+
+            configPath.Should().BeNull();
+            File.Exists(Path.Combine(tempRoot, "ripsharp", "config.yaml")).Should().BeFalse();
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveConfigPath_NonLinux_UsesApplicationDataDirectory()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"ripsharp-config-{Path.GetRandomFileName()}");
+        var appDataDir = Path.Combine(tempRoot, "appdata");
+        Directory.CreateDirectory(appDataDir);
+
+        try
+        {
+            var context = new ConfigSearchContext(
+                null,
+                Path.Combine(tempRoot, "home"),
+                appDataDir,
+                Path.Combine(tempRoot, "work"),
+                IsWindows: true,
+                IsMac: false,
+                IsLinux: false);
+
+            var configPath = ConfigFileLocator.ResolveConfigPath(
+                context,
+                isDevelopment: false,
+                File.Exists,
+                File.WriteAllText,
+                path => Directory.CreateDirectory(path));
+
+            configPath.Should().Be(Path.Combine(appDataDir, "ripsharp", "config.yaml"));
+            File.Exists(configPath).Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetDefaultConfigContents_UsesEmbeddedAppSettings()
+    {
+        var contents = ConfigFileLocator.GetDefaultConfigContents();
+
+        contents.Should().Contain("disc:");
+        contents.Should().Contain("output:");
+        contents.Should().Contain("encoding:");
+        contents.Should().Contain("metadata:");
+    }
+}

--- a/src/RipSharp/Core/ConfigFileLocator.cs
+++ b/src/RipSharp/Core/ConfigFileLocator.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace BugZapperLabs.RipSharp.Core;
+
+internal sealed record ConfigSearchContext(
+    string? XdgConfigHome,
+    string? HomeDirectory,
+    string? ApplicationDataDirectory,
+    string CurrentDirectory,
+    bool IsWindows,
+    bool IsMac,
+    bool IsLinux);
+
+internal static class ConfigFileLocator
+{
+    internal const string AppName = "ripsharp";
+    internal const string DefaultConfigFileName = "config.yaml";
+    internal const string LocalConfigFileName = "ripsharp.yaml";
+    internal const string LocalAppSettingsFileName = "appsettings.yaml";
+
+    internal const string DefaultConfigResourceName = "BugZapperLabs.RipSharp.DefaultConfig";
+
+    internal const string DefaultConfigFallbackContents = "disc:\n" +
+                                                         "  default_path: \"disc:0\"\n" +
+                                                         "  default_temp_dir: \"/tmp/makemkv\"\n\n" +
+                                                         "output:\n" +
+                                                         "  movies_dir: \"~/Movies\"\n" +
+                                                         "  tv_dir: \"~/TV\"\n\n" +
+                                                         "encoding:\n" +
+                                                         "  include_english_subtitles: true\n" +
+                                                         "  include_stereo_audio: true\n" +
+                                                         "  include_surround_audio: true\n\n" +
+                                                         "metadata:\n" +
+                                                         "  lookup_enabled: true\n";
+
+    internal static ConfigSearchContext CreateContext()
+    {
+        return new ConfigSearchContext(
+            Environment.GetEnvironmentVariable("XDG_CONFIG_HOME"),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            Directory.GetCurrentDirectory(),
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS(),
+            OperatingSystem.IsLinux());
+    }
+
+    internal static IReadOnlyList<string> GetCandidatePaths(ConfigSearchContext context)
+    {
+        var candidates = new List<string>();
+
+        if (context.IsLinux)
+        {
+            var xdgPath = GetLinuxXdgConfigPath(context);
+            if (!string.IsNullOrWhiteSpace(xdgPath))
+            {
+                candidates.Add(xdgPath);
+            }
+
+            var homeConfigPath = GetLinuxHomeConfigPath(context);
+            if (!string.IsNullOrWhiteSpace(homeConfigPath) && !PathsEqual(homeConfigPath, xdgPath))
+            {
+                candidates.Add(homeConfigPath);
+            }
+
+            var homeDotFile = GetHomeDotFilePath(context);
+            if (!string.IsNullOrWhiteSpace(homeDotFile))
+            {
+                candidates.Add(homeDotFile);
+            }
+        }
+        else
+        {
+            var preferred = GetPreferredConfigPath(context);
+            if (!string.IsNullOrWhiteSpace(preferred))
+            {
+                candidates.Add(preferred);
+            }
+
+            var homeDotFile = GetHomeDotFilePath(context);
+            if (!string.IsNullOrWhiteSpace(homeDotFile) && !PathsEqual(homeDotFile, preferred))
+            {
+                candidates.Add(homeDotFile);
+            }
+        }
+
+        AddCurrentDirectoryCandidates(context, candidates);
+        return candidates;
+    }
+
+    internal static string? ResolveConfigPath(
+        ConfigSearchContext context,
+        bool isDevelopment,
+        Func<string, bool> fileExists,
+        Action<string, string> writeFile,
+        Action<string> ensureDirectory)
+    {
+        var candidates = GetCandidatePaths(context);
+        var existing = FindExistingConfigPath(candidates, fileExists);
+        if (!string.IsNullOrWhiteSpace(existing))
+        {
+            return existing;
+        }
+
+        if (isDevelopment)
+        {
+            return null;
+        }
+
+        var preferred = GetFirstPersonalConfigPath(context);
+        if (string.IsNullOrWhiteSpace(preferred))
+        {
+            return null;
+        }
+
+        var preferredDir = Path.GetDirectoryName(preferred);
+        if (!string.IsNullOrWhiteSpace(preferredDir))
+        {
+            ensureDirectory(preferredDir);
+        }
+
+        if (!fileExists(preferred))
+        {
+            writeFile(preferred, GetDefaultConfigContents());
+        }
+
+        return preferred;
+    }
+
+    internal static string? FindExistingConfigPath(IEnumerable<string> candidates, Func<string, bool> fileExists)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (fileExists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    internal static string? GetPreferredConfigPath(ConfigSearchContext context)
+    {
+        if (context.IsLinux)
+        {
+            return GetLinuxXdgConfigPath(context) ?? GetLinuxHomeConfigPath(context);
+        }
+
+        if (!string.IsNullOrWhiteSpace(context.ApplicationDataDirectory))
+        {
+            return Path.Combine(context.ApplicationDataDirectory, AppName, DefaultConfigFileName);
+        }
+
+        return GetHomeDotFilePath(context);
+    }
+
+    internal static string? GetFirstPersonalConfigPath(ConfigSearchContext context)
+    {
+        foreach (var candidate in GetPersonalConfigPaths(context))
+        {
+            if (!string.IsNullOrWhiteSpace(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    internal static IReadOnlyList<string> GetPersonalConfigPaths(ConfigSearchContext context)
+    {
+        var candidates = new List<string>();
+
+        if (context.IsLinux)
+        {
+            var xdgPath = GetLinuxXdgConfigPath(context);
+            if (!string.IsNullOrWhiteSpace(xdgPath))
+            {
+                candidates.Add(xdgPath);
+            }
+
+            var homeConfigPath = GetLinuxHomeConfigPath(context);
+            if (!string.IsNullOrWhiteSpace(homeConfigPath) && !PathsEqual(homeConfigPath, xdgPath))
+            {
+                candidates.Add(homeConfigPath);
+            }
+
+            var homeDotFile = GetHomeDotFilePath(context);
+            if (!string.IsNullOrWhiteSpace(homeDotFile))
+            {
+                candidates.Add(homeDotFile);
+            }
+
+            return candidates;
+        }
+
+        if (!string.IsNullOrWhiteSpace(context.ApplicationDataDirectory))
+        {
+            candidates.Add(Path.Combine(context.ApplicationDataDirectory, AppName, DefaultConfigFileName));
+        }
+
+        var homeDot = GetHomeDotFilePath(context);
+        if (!string.IsNullOrWhiteSpace(homeDot))
+        {
+            candidates.Add(homeDot);
+        }
+
+        return candidates;
+    }
+
+    internal static string GetDefaultConfigContents()
+    {
+        var embedded = ReadEmbeddedDefaultConfig();
+        return string.IsNullOrWhiteSpace(embedded) ? DefaultConfigFallbackContents : embedded;
+    }
+
+    private static string? ReadEmbeddedDefaultConfig()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        using var stream = assembly.GetManifestResourceStream(DefaultConfigResourceName);
+        if (stream is null)
+        {
+            return null;
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static string? GetLinuxXdgConfigPath(ConfigSearchContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.XdgConfigHome))
+        {
+            return null;
+        }
+
+        return Path.Combine(context.XdgConfigHome, AppName, DefaultConfigFileName);
+    }
+
+    private static string? GetLinuxHomeConfigPath(ConfigSearchContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.HomeDirectory))
+        {
+            return null;
+        }
+
+        return Path.Combine(context.HomeDirectory, ".config", AppName, DefaultConfigFileName);
+    }
+
+    private static string? GetHomeDotFilePath(ConfigSearchContext context)
+    {
+        if (string.IsNullOrWhiteSpace(context.HomeDirectory))
+        {
+            return null;
+        }
+
+        return Path.Combine(context.HomeDirectory, ".ripsharp.yaml");
+    }
+
+    private static void AddCurrentDirectoryCandidates(ConfigSearchContext context, List<string> candidates)
+    {
+        if (string.IsNullOrWhiteSpace(context.CurrentDirectory))
+        {
+            return;
+        }
+
+        candidates.Add(Path.Combine(context.CurrentDirectory, LocalConfigFileName));
+        candidates.Add(Path.Combine(context.CurrentDirectory, LocalAppSettingsFileName));
+    }
+
+    private static bool PathsEqual(string? left, string? right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/RipSharp/Core/Program.cs
+++ b/src/RipSharp/Core/Program.cs
@@ -63,7 +63,19 @@ public class Program
             .ConfigureAppConfiguration((ctx, cfg) =>
             {
                 cfg.Sources.Clear();
-                cfg.AddYamlFile("appsettings.yaml", optional: true, reloadOnChange: true);
+                var configContext = ConfigFileLocator.CreateContext();
+                var configPath = ConfigFileLocator.ResolveConfigPath(
+                    configContext,
+                    ctx.HostingEnvironment.IsDevelopment(),
+                    File.Exists,
+                    File.WriteAllText,
+                    path => Directory.CreateDirectory(path));
+
+                if (!string.IsNullOrWhiteSpace(configPath))
+                {
+                    cfg.AddYamlFile(configPath, optional: false, reloadOnChange: true);
+                }
+
                 cfg.AddEnvironmentVariables();
             })
             .ConfigureServices((ctx, services) =>

--- a/src/RipSharp/Core/appsettings.yaml
+++ b/src/RipSharp/Core/appsettings.yaml
@@ -3,8 +3,8 @@ disc:
   default_temp_dir: "/tmp/makemkv"
 
 output:
-  movies_dir: "~/Movies"
-  tv_dir: "~/TV"
+  movies_dir: "~/Videos/Movies"
+  tv_dir: "~/Videos/TV"
 
 encoding:
   include_english_subtitles: true

--- a/src/RipSharp/Properties/AssemblyInfo.cs
+++ b/src/RipSharp/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RipSharp.Tests")]

--- a/src/RipSharp/RipSharp.csproj
+++ b/src/RipSharp/RipSharp.csproj
@@ -20,4 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Core/appsettings.yaml" LogicalName="BugZapperLabs.RipSharp.DefaultConfig" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add config discovery across OS-specific locations and auto-create defaults
- embed appsettings.yaml as the default config template
- document config file locations in README
- add tests for config path selection and defaults

## Testing
- runTests