### PR TITLE
Check prerequisites on startup

### DIFF
--- a/src/RipSharp.Tests/Core/ConfigFileLocatorTests.cs
+++ b/src/RipSharp.Tests/Core/ConfigFileLocatorTests.cs
@@ -1,11 +1,4 @@
-using System;
-using System.IO;
-
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Core;
+namespace RipSharp.Tests.Core;
 
 public class ConfigFileLocatorTests
 {

--- a/src/RipSharp.Tests/Core/PrerequisiteCheckerTests.cs
+++ b/src/RipSharp.Tests/Core/PrerequisiteCheckerTests.cs
@@ -1,0 +1,131 @@
+namespace RipSharp.Tests.Core;
+
+public class PrerequisiteCheckerTests
+{
+    [Fact]
+    public void GetMissingTools_WhenPathIsEmpty_ReturnsAllRequiredTools()
+    {
+        var missing = PrerequisiteChecker.GetMissingTools(null, isWindows: false, _ => false);
+
+        missing.Should().Contain(PrerequisiteChecker.RequiredTools);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonWindowsAllPresentCases))]
+    public void GetMissingTools_WhenNonWindowsPathsContainTools_ReturnsNoneMissing(string pathValue, string[] existingFiles)
+    {
+        var missing = PrerequisiteChecker.GetMissingTools(pathValue, isWindows: false, CreateSet(existingFiles).Contains);
+
+        missing.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(NonWindowsMissingCases))]
+    public void GetMissingTools_WhenNonWindowsMissingTool_ReturnsMissingTool(string pathValue, string[] existingFiles, string expectedMissing)
+    {
+        var missing = PrerequisiteChecker.GetMissingTools(pathValue, isWindows: false, CreateSet(existingFiles).Contains);
+
+        missing.Should().ContainSingle().Which.Should().Be(expectedMissing);
+    }
+
+    [Theory]
+    [MemberData(nameof(WindowsAllPresentCases))]
+    public void GetMissingTools_WhenWindowsPathsContainExecutableExtensions_ReturnsNoneMissing(string pathValue, string[] existingFiles)
+    {
+        var missing = PrerequisiteChecker.GetMissingTools(pathValue, isWindows: true, CreateSet(existingFiles).Contains);
+
+        missing.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(WindowsMissingCases))]
+    public void GetMissingTools_WhenWindowsMissingTool_ReturnsMissingTool(string pathValue, string[] existingFiles, string expectedMissing)
+    {
+        var missing = PrerequisiteChecker.GetMissingTools(pathValue, isWindows: true, CreateSet(existingFiles).Contains);
+
+        missing.Should().ContainSingle().Which.Should().Be(expectedMissing);
+    }
+
+    public static IEnumerable<object[]> NonWindowsAllPresentCases()
+    {
+        yield return new object[]
+        {
+            BuildPath("/usr/local/bin", "/usr/bin"),
+            new[] { Path.Combine("/usr/bin", "makemkvcon"), Path.Combine("/usr/local/bin", "ffmpeg") }
+        };
+
+        yield return new object[]
+        {
+            BuildPath("/usr/bin", "/opt/bin"),
+            new[] { Path.Combine("/usr/bin", "makemkvcon"), Path.Combine("/opt/bin", "ffmpeg") }
+        };
+
+        yield return new object[]
+        {
+            BuildPath("/opt/homebrew/bin", "/usr/local/bin"),
+            new[] { Path.Combine("/opt/homebrew/bin", "ffmpeg"), Path.Combine("/usr/local/bin", "makemkvcon") }
+        };
+    }
+
+    public static IEnumerable<object[]> NonWindowsMissingCases()
+    {
+        yield return new object[]
+        {
+            BuildPath("/usr/bin", "/opt/bin"),
+            new[] { Path.Combine("/opt/bin", "ffmpeg") },
+            "makemkvcon"
+        };
+
+        yield return new object[]
+        {
+            BuildPath("/usr/bin", "/opt/bin"),
+            new[] { Path.Combine("/usr/bin", "makemkvcon") },
+            "ffmpeg"
+        };
+
+        yield return new object[]
+        {
+            BuildPath("/opt/homebrew/bin", "/usr/local/bin"),
+            new[] { Path.Combine("/opt/homebrew/bin", "ffmpeg") },
+            "makemkvcon"
+        };
+    }
+
+    public static IEnumerable<object[]> WindowsAllPresentCases()
+    {
+        var baseDir = Path.Combine("C_Tools");
+        yield return new object[]
+        {
+            BuildPath(baseDir),
+            new[] { Path.Combine(baseDir, "makemkvcon.exe"), Path.Combine(baseDir, "ffmpeg.cmd") }
+        };
+    }
+
+    public static IEnumerable<object[]> WindowsMissingCases()
+    {
+        var baseDir = Path.Combine("C_Tools");
+        yield return new object[]
+        {
+            BuildPath(baseDir),
+            new[] { Path.Combine(baseDir, "makemkvcon.exe") },
+            "ffmpeg"
+        };
+
+        yield return new object[]
+        {
+            BuildPath(baseDir),
+            new[] { Path.Combine(baseDir, "ffmpeg.exe") },
+            "makemkvcon"
+        };
+    }
+
+    private static string BuildPath(params string[] parts)
+    {
+        return string.Join(Path.PathSeparator, parts);
+    }
+
+    private static HashSet<string> CreateSet(IEnumerable<string> paths)
+    {
+        return new HashSet<string>(paths, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/RipSharp.Tests/Core/RipOptionsTests.cs
+++ b/src/RipSharp.Tests/Core/RipOptionsTests.cs
@@ -1,13 +1,4 @@
-using System;
-using System.IO;
-
-using AwesomeAssertions;
-
-using BugZapperLabs.RipSharp;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Core;
+namespace RipSharp.Tests.Core;
 
 public class RipOptionsTests
 {

--- a/src/RipSharp.Tests/GlobalUsings.cs
+++ b/src/RipSharp.Tests/GlobalUsings.cs
@@ -8,3 +8,7 @@ global using BugZapperLabs.RipSharp.Metadata;
 global using BugZapperLabs.RipSharp.Models;
 global using BugZapperLabs.RipSharp.Services;
 global using BugZapperLabs.RipSharp.Utilities;
+
+global using NSubstitute;
+
+global using Xunit;

--- a/src/RipSharp.Tests/MakeMkv/MakeMkvProtocolTests.cs
+++ b/src/RipSharp.Tests/MakeMkv/MakeMkvProtocolTests.cs
@@ -1,8 +1,4 @@
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.MakeMkv;
+namespace RipSharp.Tests.MakeMkv;
 
 public class MakeMkvProtocolTests
 {

--- a/src/RipSharp.Tests/Metadata/MetadataServiceTests.cs
+++ b/src/RipSharp.Tests/Metadata/MetadataServiceTests.cs
@@ -1,14 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using AwesomeAssertions;
-
-using NSubstitute;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Metadata;
+namespace RipSharp.Tests.Metadata;
 
 public class MetadataServiceTests : IDisposable
 {

--- a/src/RipSharp.Tests/Metadata/OmdbMetadataProviderTests.cs
+++ b/src/RipSharp.Tests/Metadata/OmdbMetadataProviderTests.cs
@@ -1,16 +1,6 @@
-using System;
 using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 
-using AwesomeAssertions;
-
-using NSubstitute;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Metadata;
+namespace RipSharp.Tests.Metadata;
 
 public class OmdbMetadataProviderTests
 {

--- a/src/RipSharp.Tests/Metadata/TitleVariationGeneratorEdgeCasesTests.cs
+++ b/src/RipSharp.Tests/Metadata/TitleVariationGeneratorEdgeCasesTests.cs
@@ -1,8 +1,4 @@
-using System.Collections.Generic;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Metadata;
+namespace RipSharp.Tests.Metadata;
 
 public class TitleVariationGeneratorEdgeCasesTests
 {

--- a/src/RipSharp.Tests/Metadata/TitleVariationGeneratorTests.cs
+++ b/src/RipSharp.Tests/Metadata/TitleVariationGeneratorTests.cs
@@ -1,8 +1,4 @@
-using System.Collections.Generic;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Metadata;
+namespace RipSharp.Tests.Metadata;
 
 public class TitleVariationGeneratorTests
 {

--- a/src/RipSharp.Tests/Metadata/TmdbMetadataProviderTests.cs
+++ b/src/RipSharp.Tests/Metadata/TmdbMetadataProviderTests.cs
@@ -1,16 +1,6 @@
-using System;
 using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 
-using AwesomeAssertions;
-
-using NSubstitute;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Metadata;
+namespace RipSharp.Tests.Metadata;
 
 public class TmdbMetadataProviderTests
 {

--- a/src/RipSharp.Tests/Services/DiscRipperOverallProgressTests.cs
+++ b/src/RipSharp.Tests/Services/DiscRipperOverallProgressTests.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Reflection;
 
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Services;
+namespace RipSharp.Tests.Services;
 
 public class DiscRipperOverallProgressTests
 {

--- a/src/RipSharp.Tests/Services/DiscRipperRipSummaryTests.cs
+++ b/src/RipSharp.Tests/Services/DiscRipperRipSummaryTests.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Reflection;
 
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Services;
+namespace RipSharp.Tests.Services;
 
 public class DiscRipperRipSummaryTests
 {

--- a/src/RipSharp.Tests/Services/DiscRipperTitleSuffixTests.cs
+++ b/src/RipSharp.Tests/Services/DiscRipperTitleSuffixTests.cs
@@ -1,17 +1,7 @@
 using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 
-using AwesomeAssertions;
-
-using NSubstitute;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Services;
+namespace RipSharp.Tests.Services;
 
 public class DiscRipperTitleSuffixTests
 {

--- a/src/RipSharp.Tests/Services/DiscTypeDetectorTests.cs
+++ b/src/RipSharp.Tests/Services/DiscTypeDetectorTests.cs
@@ -1,8 +1,4 @@
-using System.Collections.Generic;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Services;
+namespace RipSharp.Tests.Services;
 
 public class DiscTypeDetectorTests
 {

--- a/src/RipSharp.Tests/Utilities/CursorManagerTests.cs
+++ b/src/RipSharp.Tests/Utilities/CursorManagerTests.cs
@@ -1,4 +1,4 @@
-namespace BugZapperLabs.RipSharp.Tests.Utilities;
+namespace RipSharp.Tests.Utilities;
 
 public class CursorManagerTests
 {

--- a/src/RipSharp.Tests/Utilities/DurationFormatterTests.cs
+++ b/src/RipSharp.Tests/Utilities/DurationFormatterTests.cs
@@ -1,8 +1,4 @@
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Utilities;
+namespace RipSharp.Tests.Utilities;
 
 public class DurationFormatterTests
 {

--- a/src/RipSharp.Tests/Utilities/FileNamingTests.cs
+++ b/src/RipSharp.Tests/Utilities/FileNamingTests.cs
@@ -1,10 +1,4 @@
-using System.IO;
-
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Utilities;
+namespace RipSharp.Tests.Utilities;
 
 public class FileNamingTests
 {

--- a/src/RipSharp.Tests/Utilities/SpectreProgressDisplayTests.cs
+++ b/src/RipSharp.Tests/Utilities/SpectreProgressDisplayTests.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Reflection;
 
-using AwesomeAssertions;
-
-using Xunit;
-
-namespace BugZapperLabs.RipSharp.Tests.Utilities;
+namespace RipSharp.Tests.Utilities;
 
 public class SpectreProgressDisplayTests
 {

--- a/src/RipSharp/Abstractions/IMakeMkvService.cs
+++ b/src/RipSharp/Abstractions/IMakeMkvService.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.Abstractions;
 
 public interface IMakeMkvService

--- a/src/RipSharp/Abstractions/IMetadataProvider.cs
+++ b/src/RipSharp/Abstractions/IMetadataProvider.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.Abstractions;
 
 public interface IMetadataProvider

--- a/src/RipSharp/Abstractions/ITvEpisodeTitleProvider.cs
+++ b/src/RipSharp/Abstractions/ITvEpisodeTitleProvider.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.Abstractions;
 
 public interface ITvEpisodeTitleProvider

--- a/src/RipSharp/Core/AppConfig.cs
+++ b/src/RipSharp/Core/AppConfig.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Configuration;
-
 namespace BugZapperLabs.RipSharp.Core;
 
 public class AppConfig

--- a/src/RipSharp/Core/ConfigFileLocator.cs
+++ b/src/RipSharp/Core/ConfigFileLocator.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 
 namespace BugZapperLabs.RipSharp.Core;

--- a/src/RipSharp/Core/PrerequisiteChecker.cs
+++ b/src/RipSharp/Core/PrerequisiteChecker.cs
@@ -1,0 +1,72 @@
+namespace BugZapperLabs.RipSharp.Core;
+
+internal static class PrerequisiteChecker
+{
+    internal static readonly string[] RequiredTools =
+    {
+        "makemkvcon",
+        "ffmpeg"
+    };
+
+    internal static IReadOnlyList<string> GetMissingTools(string? pathValue, bool isWindows, Func<string, bool> fileExists)
+    {
+        var missing = new List<string>();
+
+        foreach (var tool in RequiredTools)
+        {
+            if (!IsToolAvailable(tool, pathValue, isWindows, fileExists))
+            {
+                missing.Add(tool);
+            }
+        }
+
+        return missing;
+    }
+
+    internal static bool IsToolAvailable(string tool, string? pathValue, bool isWindows, Func<string, bool> fileExists)
+    {
+        if (string.IsNullOrWhiteSpace(pathValue))
+        {
+            return false;
+        }
+
+        foreach (var dir in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = dir.Trim().Trim('"');
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                continue;
+            }
+
+            foreach (var candidate in GetExecutableCandidates(tool, isWindows))
+            {
+                var fullPath = Path.Combine(trimmed, candidate);
+                if (fileExists(fullPath))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetExecutableCandidates(string tool, bool isWindows)
+    {
+        if (!isWindows)
+        {
+            yield return tool;
+            yield break;
+        }
+
+        if (Path.HasExtension(tool))
+        {
+            yield return tool;
+            yield break;
+        }
+
+        yield return tool + ".exe";
+        yield return tool + ".cmd";
+        yield return tool + ".bat";
+    }
+}

--- a/src/RipSharp/Core/Program.cs
+++ b/src/RipSharp/Core/Program.cs
@@ -1,18 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Reflection;
-using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
-using NetEscapades.Configuration.Yaml;
-
-using Spectre.Console;
 
 
 namespace BugZapperLabs.RipSharp.Core;
@@ -57,6 +47,45 @@ public class Program
         {
             Console.WriteLine($"ripsharp {GetVersion()}");
             return 0;
+        }
+
+        var missingTools = PrerequisiteChecker.GetMissingTools(
+            Environment.GetEnvironmentVariable("PATH"),
+            OperatingSystem.IsWindows(),
+            File.Exists);
+
+        if (missingTools.Count > 0)
+        {
+            var prereqWriter = new ConsoleWriter();
+            prereqWriter.Error("Missing required prerequisites:");
+            foreach (var tool in missingTools)
+            {
+                prereqWriter.Error($"  - {tool}");
+            }
+
+            prereqWriter.Plain("");
+            prereqWriter.Info("Install instructions:");
+            if (OperatingSystem.IsWindows())
+            {
+                prereqWriter.Plain("  - winget install --id Gyan.FFmpeg");
+                prereqWriter.Plain("  - Download MakeMKV: https://www.makemkv.com/");
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                prereqWriter.Plain("  - brew install ffmpeg");
+                prereqWriter.Plain("  - Download MakeMKV: https://www.makemkv.com/");
+            }
+            else
+            {
+                prereqWriter.Plain("  - Ubuntu/Debian: sudo apt install ffmpeg");
+                prereqWriter.Plain("  - Fedora: sudo dnf install ffmpeg");
+                prereqWriter.Plain("  - Arch: sudo pacman -S ffmpeg");
+                prereqWriter.Plain("  - openSUSE: sudo zypper install ffmpeg");
+                prereqWriter.Plain("  - Alpine: sudo apk add ffmpeg");
+                prereqWriter.Plain("  - MakeMKV: https://www.makemkv.com/");
+            }
+
+            return 2;
         }
 
         using var host = Host.CreateDefaultBuilder(args)

--- a/src/RipSharp/Core/RipOptions.cs
+++ b/src/RipSharp/Core/RipOptions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace BugZapperLabs.RipSharp.Core;
 
 public class RipOptions

--- a/src/RipSharp/MakeMkv/MakeMkvOutputHandler.cs
+++ b/src/RipSharp/MakeMkv/MakeMkvOutputHandler.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using System.Text.RegularExpressions;
 
 namespace BugZapperLabs.RipSharp.MakeMkv;

--- a/src/RipSharp/MakeMkv/MakeMkvService.cs
+++ b/src/RipSharp/MakeMkv/MakeMkvService.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.MakeMkv;
 
 public class MakeMkvService : IMakeMkvService

--- a/src/RipSharp/MakeMkv/ScanOutputHandler.cs
+++ b/src/RipSharp/MakeMkv/ScanOutputHandler.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace BugZapperLabs.RipSharp.MakeMkv;

--- a/src/RipSharp/Metadata/MetadataService.cs
+++ b/src/RipSharp/Metadata/MetadataService.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.Metadata;
 
 public class MetadataService : IMetadataService

--- a/src/RipSharp/Metadata/NullEpisodeTitleProvider.cs
+++ b/src/RipSharp/Metadata/NullEpisodeTitleProvider.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.Metadata;
 
 public class NullEpisodeTitleProvider : ITvEpisodeTitleProvider

--- a/src/RipSharp/Metadata/OmdbMetadataProvider.cs
+++ b/src/RipSharp/Metadata/OmdbMetadataProvider.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Net.Http;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace BugZapperLabs.RipSharp.Metadata;
 

--- a/src/RipSharp/Metadata/TitleVariationGenerator.cs
+++ b/src/RipSharp/Metadata/TitleVariationGenerator.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace BugZapperLabs.RipSharp.Metadata;
 
 public static class TitleVariationGenerator

--- a/src/RipSharp/Metadata/TmdbMetadataProvider.cs
+++ b/src/RipSharp/Metadata/TmdbMetadataProvider.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Net.Http;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace BugZapperLabs.RipSharp.Metadata;
 

--- a/src/RipSharp/Metadata/TvdbMetadataProvider.cs
+++ b/src/RipSharp/Metadata/TvdbMetadataProvider.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Collections.Concurrent;
-using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace BugZapperLabs.RipSharp.Metadata;
 

--- a/src/RipSharp/Models/ContentMetadata.cs
+++ b/src/RipSharp/Models/ContentMetadata.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace BugZapperLabs.RipSharp.Models;
 
 public class ContentMetadata

--- a/src/RipSharp/Services/DiscRipper.cs
+++ b/src/RipSharp/Services/DiscRipper.cs
@@ -1,13 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
-
-using Spectre.Console;
 
 
 namespace BugZapperLabs.RipSharp.Services;

--- a/src/RipSharp/Services/DiscScanner.cs
+++ b/src/RipSharp/Services/DiscScanner.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace BugZapperLabs.RipSharp.Services;
 

--- a/src/RipSharp/Services/DiscTypeDetector.cs
+++ b/src/RipSharp/Services/DiscTypeDetector.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace BugZapperLabs.RipSharp.Services;
 
 /// <summary>

--- a/src/RipSharp/Services/EncoderService.cs
+++ b/src/RipSharp/Services/EncoderService.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 
 namespace BugZapperLabs.RipSharp.Services;

--- a/src/RipSharp/Services/ProcessRunner.cs
+++ b/src/RipSharp/Services/ProcessRunner.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace BugZapperLabs.RipSharp.Services;
 

--- a/src/RipSharp/Utilities/FileNaming.cs
+++ b/src/RipSharp/Utilities/FileNaming.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace BugZapperLabs.RipSharp.Utilities;
 
 public static class FileNaming

--- a/src/RipSharp/Utilities/SpectreProgressDisplay.cs
+++ b/src/RipSharp/Utilities/SpectreProgressDisplay.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Spectre.Console;
 using Spectre.Console.Rendering;
 


### PR DESCRIPTION
## Summary
- add prerequisite detection for makemkvcon and ffmpeg at startup with install guidance
- add PrerequisiteChecker with OS/path aware lookup
- add unit tests covering Windows, macOS, and Linux scenarios
- include related updates from the branch

## Testing
- dotnet format RipSharp.sln
- dotnet test RipSharp.sln